### PR TITLE
Add grpc service registration helper that adds default middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -2,9 +2,14 @@ package grpcutil
 
 import (
 	"context"
+	"fmt"
 
+	grpcmw "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpcvalidate "github.com/grpc-ecosystem/go-grpc-middleware/validator"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // IgnoreAuthMixin is a struct that can be embedded to make a gRPC handler
@@ -30,4 +35,67 @@ type AuthlessHealthServer struct {
 // middleware.
 func NewAuthlessHealthServer() *AuthlessHealthServer {
 	return &AuthlessHealthServer{Server: health.NewServer()}
+}
+
+// SetServicesHealthy sets the service to SERVING
+func (s *AuthlessHealthServer) SetServicesHealthy(svcDesc ...*grpc.ServiceDesc) {
+	for _, d := range svcDesc {
+		s.SetServingStatus(
+			d.ServiceName,
+			healthpb.HealthCheckResponse_SERVING,
+		)
+	}
+}
+
+// DefaultUnaryMiddleware is a recommended set of middleware that should each gracefully no-op if the middleware is not
+// applicable.
+var DefaultUnaryMiddleware = []grpc.UnaryServerInterceptor{grpcvalidate.UnaryServerInterceptor()}
+
+// WrapMethods wraps all non-streaming endpoints with the given list of interceptors.
+// It returns a copy of the ServiceDesc with the new wrapped methods.
+func WrapMethods(svcDesc grpc.ServiceDesc, interceptors ...grpc.UnaryServerInterceptor) (wrapped *grpc.ServiceDesc) {
+	chain := grpcmw.ChainUnaryServer(interceptors...)
+	for i, m := range svcDesc.Methods {
+		handler := m.Handler
+		wrapped := grpc.MethodDesc{
+			MethodName: m.MethodName,
+			Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+				if interceptor == nil {
+					interceptor = NoopUnaryInterceptor
+				}
+				return handler(srv, ctx, dec, grpcmw.ChainUnaryServer(interceptor, chain))
+			},
+		}
+		svcDesc.Methods[i] = wrapped
+	}
+	return &svcDesc
+}
+
+// WrapStreams wraps all streaming endpoints with the given list of interceptors.
+// It returns a copy of the ServiceDesc with the new wrapped methods.
+func WrapStreams(svcDesc grpc.ServiceDesc, interceptors ...grpc.StreamServerInterceptor) (wrapped *grpc.ServiceDesc) {
+	chain := grpcmw.ChainStreamServer(interceptors...)
+	for i, s := range svcDesc.Streams {
+		handler := s.Handler
+		info := &grpc.StreamServerInfo{
+			FullMethod:     fmt.Sprintf("/%s/%s", svcDesc.ServiceName, s.StreamName),
+			IsClientStream: s.ClientStreams,
+			IsServerStream: s.ServerStreams,
+		}
+		wrapped := grpc.StreamDesc{
+			StreamName:    s.StreamName,
+			ClientStreams: s.ClientStreams,
+			ServerStreams: s.ServerStreams,
+			Handler: func(srv interface{}, stream grpc.ServerStream) error {
+				return chain(srv, stream, info, handler)
+			},
+		}
+		svcDesc.Streams[i] = wrapped
+	}
+	return &svcDesc
+}
+
+// NoopUnaryInterceptor is a gRPC middleware that does not do anything.
+func NoopUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return handler(ctx, req)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,276 @@
+package grpcutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+	testpb "google.golang.org/grpc/test/grpc_testing"
+)
+
+func TestWrapMethodsNoop(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+	s.RegisterService(WrapMethods(testpb.TestService_ServiceDesc, NoopUnaryInterceptor), &testServer{})
+	go s.Serve(lis)
+
+	conn, err := grpc.Dial("", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	if err != nil {
+		t.Error(err)
+	}
+	client := testpb.NewTestServiceClient(conn)
+	_, err = client.UnaryCall(context.Background(), &testpb.SimpleRequest{ResponseType: testpb.PayloadType_COMPRESSABLE, ResponseSize: 1})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWrapMethods(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+
+	middleware := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		sr := req.(*testpb.SimpleRequest)
+		sr.ResponseSize++
+		return handler(ctx, req)
+	}
+	s.RegisterService(WrapMethods(testpb.TestService_ServiceDesc, middleware), &testServer{})
+	go s.Serve(lis)
+
+	conn, err := grpc.Dial("", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	if err != nil {
+		t.Error(err)
+	}
+	client := testpb.NewTestServiceClient(conn)
+	resp, err := client.UnaryCall(context.Background(), &testpb.SimpleRequest{ResponseType: testpb.PayloadType_COMPRESSABLE, ResponseSize: 1})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resp.Payload.Body) != 2 {
+		t.Error("request not intercepted")
+	}
+}
+
+func TestWrapMethodsAndServerInterceptor(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+
+	serverMiddleware := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		r, err := handler(ctx, req)
+		sr := r.(*testpb.SimpleResponse)
+		sr.Payload.Body = append(sr.Payload.Body, byte(2))
+		return sr, err
+	}
+	s := grpc.NewServer(grpc.ChainUnaryInterceptor(serverMiddleware))
+
+	middleware := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		r, err := handler(ctx, req)
+		sr := r.(*testpb.SimpleResponse)
+		sr.Payload.Body = append(sr.Payload.Body, byte(1))
+		return sr, err
+	}
+	s.RegisterService(WrapMethods(testpb.TestService_ServiceDesc, middleware), &testServer{})
+	go s.Serve(lis)
+
+	conn, err := grpc.Dial("", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	if err != nil {
+		t.Error(err)
+	}
+	client := testpb.NewTestServiceClient(conn)
+	resp, err := client.UnaryCall(context.Background(), &testpb.SimpleRequest{ResponseType: testpb.PayloadType_COMPRESSABLE, ResponseSize: 0})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// middleware happens before server middleware
+	if string(resp.Payload.Body) != "\u0000\u0001\u0002" {
+		t.Errorf("request not intercepted, got %b", resp.Payload.Body)
+	}
+}
+
+func TestWrapStreams(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+
+	counter := 0
+	s.RegisterService(WrapStreams(testpb.TestService_ServiceDesc, StreamMiddleware(&counter)), &testServer{})
+	go s.Serve(lis)
+
+	conn, err := grpc.Dial("", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	if err != nil {
+		t.Error(err)
+	}
+	client := testpb.NewTestServiceClient(conn)
+	stream, err := client.StreamingOutputCall(context.Background(), &testpb.StreamingOutputCallRequest{
+		ResponseType: testpb.PayloadType_COMPRESSABLE,
+		ResponseParameters: []*testpb.ResponseParameters{
+			{
+				Size: 0,
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := func() error {
+		for {
+			_, err := stream.Recv()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}(); err != nil {
+		t.Error(err)
+	}
+
+	if counter != 1 {
+		t.Error("stream not intercepted")
+	}
+}
+
+func TestWrapStreamsAndServerInterceptor(t *testing.T) {
+	serverCounter := 0
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer(grpc.ChainStreamInterceptor(StreamMiddleware(&serverCounter)))
+
+	counter := 0
+	s.RegisterService(WrapStreams(testpb.TestService_ServiceDesc, StreamMiddleware(&counter)), &testServer{})
+	go s.Serve(lis)
+
+	conn, err := grpc.Dial("", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	if err != nil {
+		t.Error(err)
+	}
+	client := testpb.NewTestServiceClient(conn)
+	stream, err := client.StreamingOutputCall(context.Background(), &testpb.StreamingOutputCallRequest{
+		ResponseType: testpb.PayloadType_COMPRESSABLE,
+		ResponseParameters: []*testpb.ResponseParameters{
+			{
+				Size: 0,
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := func() error {
+		for {
+			_, err := stream.Recv()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}(); err != nil {
+		t.Error(err)
+	}
+
+	if counter != 1 || serverCounter != 1 {
+		t.Error("stream not intercepted")
+	}
+}
+
+func StreamMiddleware(counter *int) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapper := &recvWrapper{stream, counter}
+		return handler(srv, wrapper)
+	}
+}
+
+type recvWrapper struct {
+	grpc.ServerStream
+	counter *int
+}
+
+func (s *recvWrapper) RecvMsg(m interface{}) error {
+	if err := s.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	*s.counter++
+
+	return nil
+}
+
+type testServer struct {
+	testpb.UnimplementedTestServiceServer
+}
+
+func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		var str []string
+		for _, entry := range md["user-agent"] {
+			str = append(str, "ua", entry)
+		}
+		grpc.SendHeader(ctx, metadata.Pairs(str...))
+	}
+	return new(testpb.Empty), nil
+}
+
+func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	payload, err := newPayload(in.GetResponseType(), in.GetResponseSize())
+	if err != nil {
+		return nil, err
+	}
+
+	return &testpb.SimpleResponse{
+		Payload: payload,
+	}, nil
+}
+
+func (s *testServer) StreamingOutputCall(args *testpb.StreamingOutputCallRequest, stream testpb.TestService_StreamingOutputCallServer) error {
+	cs := args.GetResponseParameters()
+	for _, c := range cs {
+		payload, err := newPayload(args.GetResponseType(), c.GetSize())
+		if err != nil {
+			return err
+		}
+
+		if err := stream.Send(&testpb.StreamingOutputCallResponse{
+			Payload: payload,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newPayload(t testpb.PayloadType, size int32) (*testpb.Payload, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("requested a response with invalid length %d", size)
+	}
+	body := make([]byte, size)
+	switch t {
+	case testpb.PayloadType_COMPRESSABLE:
+	case testpb.PayloadType_UNCOMPRESSABLE:
+		return nil, fmt.Errorf("PayloadType UNCOMPRESSABLE is not supported")
+	default:
+		return nil, fmt.Errorf("unsupported payload type: %d", t)
+	}
+	return &testpb.Payload{
+		Type: t,
+		Body: body,
+	}, nil
+}


### PR DESCRIPTION
This helps to write registration functions for grpc services that shouldn't be used without certain middleware (i.e. validation)

Replaces #5 